### PR TITLE
ERC721 and ERC20 Currency Types

### DIFF
--- a/card/apdu.go
+++ b/card/apdu.go
@@ -82,6 +82,8 @@ const (
 
 	//extended tags
 	TagChainID = 0x20
+	TagPhononContractAddress = 0x58
+	TagPhononContractTokenID = 0x59
 
 	//ISO7816 Standard Responses
 	SW_APPLET_SELECT_FAILED           = 0x6999

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -14,4 +14,5 @@ var ErrUnknownCurrencyType = errors.New("unknown currency type")
 type ChainService interface {
 	DeriveAddress(p *model.Phonon) (address string, err error)
 	RedeemPhonon(p *model.Phonon, privKey *ecdsa.PrivateKey, redeemAddress string) (transactionData string, err error)
+	VerifyBalance(p *model.Phonon) (balance bool, err error)
 }

--- a/chain/ethChainService.go
+++ b/chain/ethChainService.go
@@ -74,14 +74,7 @@ func (eth *EthChainService) RedeemPhonon(p *model.Phonon, privKey *ecdsa.Private
 			}
 			return tx, nil
 
-		case model.EthereumERC721:
-			tx, err := eth.redeemToken(p, ctx, privKey, redeemAddress)
-			if err != nil {
-				return "", err
-			}
-			return tx, nil
-
-		case model.EthereumERC20:
+		case model.EthereumERC721, model.EthereumERC20:
 			tx, err := eth.redeemToken(p, ctx, privKey, redeemAddress)
 			if err != nil {
 				return "", err

--- a/chain/multiChainRouter.go
+++ b/chain/multiChainRouter.go
@@ -32,6 +32,14 @@ func (mcr *MultiChainRouter) initBuiltinChainServices() (err error) {
 	if err != nil {
 		return err
 	}
+	mcr.chainServices[model.EthereumERC721], err = NewEthChainService()
+	if err != nil {
+		return err
+	}
+	mcr.chainServices[model.EthereumERC20], err = NewEthChainService()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -50,4 +58,12 @@ func (mcr *MultiChainRouter) RedeemPhonon(p *model.Phonon, privKey *ecdsa.Privat
 		return "", ErrCurrencyTypeUnsupported
 	}
 	return chain.RedeemPhonon(p, privKey, redeemAddress)
+}
+
+func (mcr *MultiChainRouter) VerifyBalance(p *model.Phonon) (balance bool, err error) {
+	chain, ok := mcr.chainServices[p.CurrencyType]
+	if !ok {
+		return false, ErrCurrencyTypeUnsupported
+	}
+	return chain.VerifyBalance(p)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,20 +24,20 @@ type EthChainServiceConfig struct {
 func DefaultConfig() Config {
 	//Add viper/commandline integration later
 	conf := Config{
-		AppletCACert: cert.PhononDemoCAPubKey,
+		AppletCACert: cert.PhononAlphaCAPubKey, //cert.PhononDemoCAPubKey
 		LogLevel:     log.DebugLevel,
 	}
 	return conf
 }
 
 func SetDefaultConfig() {
-	viper.SetDefault("AppletCACert", cert.PhononDemoCAPubKey)
+	viper.SetDefault("AppletCACert", cert.PhononAlphaCAPubKey)
 	viper.SetDefault("LogLevel", log.DebugLevel)
 }
 
 func LoadConfig() (config Config, err error) {
 	SetDefaultConfig()
-	viper.AddConfigPath("$HOME/.phonon/")
+	viper.AddConfigPath("$HOME/Sites/senor/phonon-client/")
 	viper.AddConfigPath("$XDG_CONFIG_HOME/.phonon/phonon.yml")
 	viper.AddConfigPath("/usr/var/phonon/phonon.yml")
 	viper.SetConfigName("phonon")

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,10 @@ require (
 	github.com/posener/h2conn v0.0.0-20180911140238-13e7df33ed15
 	github.com/rs/cors v1.8.0
 	github.com/sirupsen/logrus v1.7.0
+	github.com/soysenor/eth-go-bindings v0.0.0-20220327014037-b87989c72111 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.10.1
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )

--- a/go.sum
+++ b/go.sum
@@ -666,6 +666,10 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/soysenor/eth-go-bindings v0.0.0-20220317020447-9e5e43d0693b h1:RgYqhGatKspG5ioDI25wB/bBxxT5bfKGufFGnOPrIQ4=
+github.com/soysenor/eth-go-bindings v0.0.0-20220317020447-9e5e43d0693b/go.mod h1:j5PyXkTPnd211oLvy9BuwCs96/yZl3fOCelEFM+cza0=
+github.com/soysenor/eth-go-bindings v0.0.0-20220327014037-b87989c72111 h1:Dn3GiwG/yW7QfSjBbEP+8reQm0aNtpPPs4pUixmuhYg=
+github.com/soysenor/eth-go-bindings v0.0.0-20220327014037-b87989c72111/go.mod h1:j5PyXkTPnd211oLvy9BuwCs96/yZl3fOCelEFM+cza0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=

--- a/gui/api.go
+++ b/gui/api.go
@@ -250,15 +250,21 @@ func (apiSession *apiSession) initDepositPhonons(w http.ResponseWriter, r *http.
 	var depositPhononReq struct {
 		CurrencyType  model.CurrencyType
 		Denominations []*model.Denomination
+		Tags					[][]model.PhononTag
 	}
+	log.Debug("BODY: ", r.Body)
+
 	err = json.NewDecoder(r.Body).Decode(&depositPhononReq)
 	if err != nil {
-		log.Error("unable to decode initDeposit request")
+		log.Error("unable to decode initDeposit request", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	log.Debug("depositPhononReq: ", depositPhononReq)
 	log.Debug("denoms: ", depositPhononReq.Denominations)
-	phonons, err := sess.InitDepositPhonons(depositPhononReq.CurrencyType, depositPhononReq.Denominations)
+	log.Debug("tags: ", depositPhononReq.Tags)
+
+	phonons, err := sess.InitDepositPhonons(depositPhononReq.CurrencyType, depositPhononReq.Denominations, depositPhononReq.Tags)
 	if err != nil {
 		log.Error("unable to create phonons for deposit. err: ", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/model/currencytype_string.go
+++ b/model/currencytype_string.go
@@ -11,11 +11,13 @@ func _() {
 	_ = x[Unspecified-0]
 	_ = x[Bitcoin-1]
 	_ = x[Ethereum-2]
+	_ = x[EthereumERC721-3]
+	_ = x[EthereumERC20-4]
 }
 
-const _CurrencyType_name = "UnspecifiedBitcoinEthereum"
+const _CurrencyType_name = "UnspecifiedBitcoinEthereumEthereumERC721EthereumERC20"
 
-var _CurrencyType_index = [...]uint8{0, 11, 18, 26}
+var _CurrencyType_index = [...]uint8{0, 11, 18, 26, 40, 53}
 
 func (i CurrencyType) String() string {
 	if i >= CurrencyType(len(_CurrencyType_index)-1) {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -76,7 +76,12 @@ func Start() {
 		Name: "setDescriptor",
 		Func: setDescriptor,
 		Help: `Set the metadata associated with this phonon.
-		       Args: [KeyIndex] [CurrencyType] [Value]`,
+		       Args: [KeyIndex] [CurrencyType] [Value] [ChainID] [*Tags*]`,
+	})
+	shell.AddCmd(&ishell.Cmd{
+		Name: "verifyBalance",
+		Func: verifyBalance,
+		Help: "Verify the contents of the given phonon on the blockchain",
 	})
 	shell.AddCmd(&ishell.Cmd{
 		Name: "redeem",


### PR DESCRIPTION
REPL
- Added `VerifyBalance` method.  Takes `keyIndex` for Phonon, then routes through multiChainRouter to ETHChainService, and switches between `checkERC721Balance`, `checkETHBalance`, `checkERC20Balance` pending Currency Type with support from helper function `checkFetchFromAddress`.  Go-bindings for ERC721 and ERC20 contract are currently sourced from one of my repos, but should be moved into phonon. 
- Incorporated Tagging into `SetDescriptor`.  Gets required tags for ERC721 and ERC20 (see `CurrencyTypeTagsRequired` map on model/phonon.go), prompts user for inputs (`TagPhononContractAddress` and `TagPhononContractTokenID` - see card/apdu too), and passes user inputs `[]PhononTag` to `AddTags` method on Phonon model to be structured according to TLV standard.
- Added `ChainID` as a mandatory 4th parameter for `SetDescriptor`.

GUI
- Updated `initDepositPhonons` to take `Tags` as slices of key value strings (see `[][]PhononTag`), which are parsed into TLV standard via `AddTags` method in `initDepositPhonons` in session/session.   But because `setDescriptor` isn't processed until `FinalizeDepositPhonons`, I had to work through `UnmarshalJSON` and `MarshalJSON` on model/phonon for ExtendedTLV to pass data back and forth between web and client.  I'm sure you'll have a more sophisticated approach to this, but I made it work for my tags (see `marshalTags`).  

Additional Notes:
- Currently the following work for ERC721 and ERC20:  `create`, `setDescriptor`, `initDepositPhonons`, `verifyBalance`.
- Not fully integrated: `redeem`.   You'll see I updated the `RedeemPhonon` method for EthChainService  to switch on currencyType; `redeemETH` and `redeemToken`.  This hasn't been fully tested yet.  Is a little tricky with the bug in the applet limiting currency types, and with the react app actively being worked on.  But it's close so I'm incorporating the code in anyway.  Also, I would not call redemption for ERC20 nor ERC721 fully integrated until the pre-requisite transfer of ETH to the phonon is thought out; this needs to be done in the UI.
- Added CurrencyType `EthereumERC721` and `EthereumERC20` to model/phonon.
- Known Bug: I need to talk to you about a bug I am seeing when attempting to `setDescriptor` for ERC721.   I had no issues assigning both tags, until recent updates to Master.  What I'm finding is I am able to assign my `TagPhononContractAddress` OR `TagPhononContractTokenID` tags successfully, but not BOTH at the same time, when the length of `TagPhononContractAddress` > 39.  This of course doesn't work for ERC721 since contract addresses are 42 characters, but you can see adding both tags works for ERC721 if you shorten the contract address you input.  I am probably doing something wrong, but need help understanding what's going on. 