### PR TITLE
fix all linter errors in go files

### DIFF
--- a/card/apdu.go
+++ b/card/apdu.go
@@ -243,7 +243,7 @@ func NewCommandListPhonons(p1 byte, p2 byte, data []byte) *Command {
 			SW_WRONG_DATA + 3:           errors.New("unable to decode less than TLV"),
 			SW_WRONG_DATA + 4:           errors.New("unable to decode greater than TLV"),
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_INCORRECT_P1P2:           errors.New("incorrect Parameters received"),
+			SW_INCORRECT_P1P2:           errors.New("incorrect parameters received"),
 		},
 	}
 }
@@ -329,7 +329,7 @@ func NewCommandReceivePhonons(phononTransferPacket []byte) *Command {
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: errors.New("phonon recipt conditions not met"),
 			SW_FILE_FULL:                errors.New("maximum number of phonons exceeded"),
-			SW_WRONG_DATA:               errors.New("unable to decode Phonon key list TLV"),
+			SW_WRONG_DATA:               errors.New("unable to decode phonon key list TLV"),
 		},
 	}
 }
@@ -415,7 +415,7 @@ func NewCommandCardPair2(data []byte) *Command {
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
 			SW_WRONG_DATA:               errors.New("unable to read salt"),
 			SW_WRONG_DATA + 1:           errors.New("unable to read AES TLV"),
-			SW_WRONG_DATA + 2:           errors.New("unable to read Signature TLV"),
+			SW_WRONG_DATA + 2:           errors.New("unable to read signature TLV"),
 		},
 	}
 }
@@ -432,7 +432,7 @@ func NewCommandFinalizeCardPair(data []byte) *Command {
 		PossibleErrs: CmdErrTable{
 			// No idea how you can get this far without validating a pin
 			SW_CONDITIONS_NOT_SATISFIED:      ErrPINNotEntered,
-			SW_WRONG_DATA:                    errors.New("unable to read Receiver signature TLV"),
+			SW_WRONG_DATA:                    errors.New("unable to read receiver signature TLV"),
 			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("unable to verify signature"),
 		},
 	}
@@ -513,7 +513,7 @@ func NewCommandMutualAuthenticate(data []byte) *Command {
 		ApduCmd: keycard.NewCommandMutuallyAuthenticate(data),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED:      errors.New("authentication key not initialized"),
-			SW_LOGICAL_CHANNEL_NOT_SUPPORTED: errors.New("already Mutually Authenticated"),
+			SW_LOGICAL_CHANNEL_NOT_SUPPORTED: errors.New("already mutually authenticated"),
 			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("secret length invalid"),
 		},
 	}

--- a/card/apdu.go
+++ b/card/apdu.go
@@ -238,12 +238,12 @@ func NewCommandListPhonons(p1 byte, p2 byte, data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_WRONG_DATA:               errors.New("no remaining phonons to list"),
-			SW_WRONG_DATA + 1:           errors.New("Unable to decode phonon filter TLV"),
+			SW_WRONG_DATA + 1:           errors.New("unable to decode phonon filter TLV"),
 			SW_WRONG_DATA + 2:           errors.New("unable to decode phonon currency TLV"),
-			SW_WRONG_DATA + 3:           errors.New("Unable to decode less than TLV"),
-			SW_WRONG_DATA + 4:           errors.New("Unable to decode greater than TLV"),
+			SW_WRONG_DATA + 3:           errors.New("unable to decode less than TLV"),
+			SW_WRONG_DATA + 4:           errors.New("unable to decode greater than TLV"),
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_INCORRECT_P1P2:           errors.New("Incorrect Parameters received"),
+			SW_INCORRECT_P1P2:           errors.New("incorrect Parameters received"),
 		},
 	}
 }
@@ -259,12 +259,12 @@ func NewCommandGetPhononPubKey(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_WRONG_LENGTH:             errors.New("Data length incorrect"),
-			SW_WRONG_DATA:               errors.New("Phonon index invalid"),
+			SW_WRONG_LENGTH:             errors.New("data length incorrect"),
+			SW_WRONG_DATA:               errors.New("phonon index invalid"),
 			SW_FILE_INVALID:             ErrInvalidPhononIndex,
-			SW_FILE_INVALID + 1:         errors.New("Phonon at index exceeds available phonon list"),
+			SW_FILE_INVALID + 1:         errors.New("phonon at index exceeds available phonon list"),
 			SW_FILE_INVALID + 3:         errors.New("phonon at index is null"),
-			SW_FILE_NOT_FOUND:           errors.New("Phonon not initialized"),
+			SW_FILE_NOT_FOUND:           errors.New("phonon not initialized"),
 		},
 	}
 }
@@ -280,12 +280,12 @@ func NewCommandDestroyPhonon(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_WRONG_LENGTH:             errors.New("Incoming length wrong"),
-			SW_WRONG_DATA:               errors.New("Invalid phonon index"),
+			SW_WRONG_LENGTH:             errors.New("incoming length wrong"),
+			SW_WRONG_DATA:               errors.New("invalid phonon index"),
 			SW_FILE_INVALID:             ErrInvalidPhononIndex,
-			SW_FILE_INVALID + 1:         errors.New("Phononon doesn't exist"),
+			SW_FILE_INVALID + 1:         errors.New("phononon doesn't exist"),
 			// adding 2 doesn't work because it conflicts with another error
-			SW_FILE_INVALID + 3: errors.New("Phonon already deleted"),
+			SW_FILE_INVALID + 3: errors.New("phonon already deleted"),
 		},
 	}
 }
@@ -308,9 +308,9 @@ func NewCommandSendPhonons(data []byte, p2Length byte, extendedRequest bool) *Co
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_INCORRECT_P1P2:           errors.New("PhononList continue greater than 1"),
-			SW_INCORRECT_P1P2 + 1:       errors.New("No Phonons Requested"),
-			SW_WRONG_DATA:               errors.New("Incorrect phonon index"),
+			SW_INCORRECT_P1P2:           errors.New("phononList continue greater than 1"),
+			SW_INCORRECT_P1P2 + 1:       errors.New("no Phonons Requested"),
+			SW_WRONG_DATA:               errors.New("incorrect phonon index"),
 		},
 	}
 }
@@ -327,9 +327,9 @@ func NewCommandReceivePhonons(phononTransferPacket []byte) *Command {
 			phononTransferPacket,
 		),
 		PossibleErrs: CmdErrTable{
-			SW_CONDITIONS_NOT_SATISFIED: errors.New("Phonon recipt conditions not met"),
-			SW_FILE_FULL:                errors.New("Maximum number of phonons exceeded"),
-			SW_WRONG_DATA:               errors.New("Unable to decode Phonon key list TLV"),
+			SW_CONDITIONS_NOT_SATISFIED: errors.New("phonon recipt conditions not met"),
+			SW_FILE_FULL:                errors.New("maximum number of phonons exceeded"),
+			SW_WRONG_DATA:               errors.New("unable to decode Phonon key list TLV"),
 		},
 	}
 }
@@ -346,9 +346,9 @@ func NewCommandSetReceiveList(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_FILE_FULL:                errors.New("No phonon with index passed"),
-			SW_WRONG_DATA:               errors.New("Unable to decode Phonon key list TLV"),
-			SW_WRONG_DATA + 1:           errors.New("Unable to decode phonon key TLV"),
+			SW_FILE_FULL:                errors.New("no phonon with index passed"),
+			SW_WRONG_DATA:               errors.New("unable to decode Phonon key list TLV"),
+			SW_WRONG_DATA + 1:           errors.New("unable to decode phonon key TLV"),
 		},
 	}
 }
@@ -364,7 +364,7 @@ func NewCommandTransactionAck(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_WRONG_DATA:               errors.New("Unable to decode TLV tag")},
+			SW_WRONG_DATA:               errors.New("unable to decode TLV tag")},
 	}
 }
 
@@ -379,8 +379,8 @@ func NewCommandInitCardPairing(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_WRONG_DATA:               errors.New("Unable to decode certificate TLV"),
-			SW_COMMAND_NOT_ALLOWED:      errors.New("Card certificate not initialized"),
+			SW_WRONG_DATA:               errors.New("unable to decode certificate TLV"),
+			SW_COMMAND_NOT_ALLOWED:      errors.New("card certificate not initialized"),
 		},
 	}
 }
@@ -396,8 +396,8 @@ func NewCommandCardPair(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_WRONG_DATA:               errors.New("Unable to decode card certificate TLV"),
-			SW_WRONG_DATA + 1:           errors.New("Unable to decode salt TLV"),
+			SW_WRONG_DATA:               errors.New("unable to decode card certificate TLV"),
+			SW_WRONG_DATA + 1:           errors.New("unable to decode salt TLV"),
 		},
 	}
 }
@@ -413,9 +413,9 @@ func NewCommandCardPair2(data []byte) *Command {
 		),
 		PossibleErrs: CmdErrTable{
 			SW_CONDITIONS_NOT_SATISFIED: ErrPINNotEntered,
-			SW_WRONG_DATA:               errors.New("Unable to read salt"),
-			SW_WRONG_DATA + 1:           errors.New("Unable to read AES TLV"),
-			SW_WRONG_DATA + 2:           errors.New("Unable to read Signature TLV"),
+			SW_WRONG_DATA:               errors.New("unable to read salt"),
+			SW_WRONG_DATA + 1:           errors.New("unable to read AES TLV"),
+			SW_WRONG_DATA + 2:           errors.New("unable to read Signature TLV"),
 		},
 	}
 }
@@ -432,8 +432,8 @@ func NewCommandFinalizeCardPair(data []byte) *Command {
 		PossibleErrs: CmdErrTable{
 			// No idea how you can get this far without validating a pin
 			SW_CONDITIONS_NOT_SATISFIED:      ErrPINNotEntered,
-			SW_WRONG_DATA:                    errors.New("Unable to read Receiver signature TLV"),
-			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("Unable to verify signature"),
+			SW_WRONG_DATA:                    errors.New("unable to read Receiver signature TLV"),
+			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("unable to verify signature"),
 		},
 	}
 }
@@ -448,8 +448,8 @@ func NewCommandInstallCert(data []byte) *Command {
 			data,
 		),
 		PossibleErrs: CmdErrTable{
-			SW_COMMAND_NOT_ALLOWED: errors.New("Certificate already loaded"),
-			SW_DATA_INVALID:        errors.New("Unable to save certificate"),
+			SW_COMMAND_NOT_ALLOWED: errors.New("certificate already loaded"),
+			SW_DATA_INVALID:        errors.New("unable to save certificate"),
 		},
 	}
 }
@@ -469,9 +469,9 @@ func NewCommandPairStep1(salt []byte, pairingPubKey *ecdsa.PublicKey) *Command {
 	return &Command{
 		ApduCmd: gridplus.NewAPDUPairStep1(salt, pairingPubKey),
 		PossibleErrs: CmdErrTable{
-			SW_WRONG_DATA:                     errors.New("Data incorrect size"),
-			SW_SECURE_MESSAGING_NOT_SUPPORTED: errors.New("No certificate loaded"),
-			SW_SECURITY_STATUS_NOT_SATISFIED:  errors.New("Unable to compute ECDH secrets"),
+			SW_WRONG_DATA:                     errors.New("data incorrect size"),
+			SW_SECURE_MESSAGING_NOT_SUPPORTED: errors.New("no certificate loaded"),
+			SW_SECURITY_STATUS_NOT_SATISFIED:  errors.New("unable to compute ECDH secrets"),
 		},
 	}
 
@@ -481,8 +481,8 @@ func NewCommandPairStep2(cryptogram [32]byte) *Command {
 	return &Command{
 		ApduCmd: gridplus.NewAPDUPairStep2(cryptogram[0:]),
 		PossibleErrs: CmdErrTable{
-			SW_WRONG_DATA:                    errors.New("Wrong secret length"),
-			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("Client cryptogram differs from expected"),
+			SW_WRONG_DATA:                    errors.New("wrong secret length"),
+			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("client cryptogram differs from expected"),
 		},
 	}
 
@@ -501,8 +501,8 @@ func NewCommandOpenSecureChannel(index uint8, publicKey []byte) *Command {
 	return &Command{
 		ApduCmd: keycard.NewCommandOpenSecureChannel(index, publicKey),
 		PossibleErrs: CmdErrTable{
-			SW_INCORRECT_P1P2:                errors.New("Incorrect parameters"),
-			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("Unable to generate secret"),
+			SW_INCORRECT_P1P2:                errors.New("incorrect parameters"),
+			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("unable to generate secret"),
 		},
 	}
 
@@ -512,9 +512,9 @@ func NewCommandMutualAuthenticate(data []byte) *Command {
 	return &Command{
 		ApduCmd: keycard.NewCommandMutuallyAuthenticate(data),
 		PossibleErrs: CmdErrTable{
-			SW_CONDITIONS_NOT_SATISFIED:      errors.New("Authentication key not initialized"),
-			SW_LOGICAL_CHANNEL_NOT_SUPPORTED: errors.New("Already Mutually Authenticated"),
-			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("Secret length invalid"),
+			SW_CONDITIONS_NOT_SATISFIED:      errors.New("authentication key not initialized"),
+			SW_LOGICAL_CHANNEL_NOT_SUPPORTED: errors.New("already Mutually Authenticated"),
+			SW_SECURITY_STATUS_NOT_SATISFIED: errors.New("secret length invalid"),
 		},
 	}
 

--- a/card/phonon.go
+++ b/card/phonon.go
@@ -3,6 +3,7 @@ package card
 import (
 	"encoding/binary"
 	"errors"
+
 	"github.com/GridPlus/phonon-client/model"
 	"github.com/GridPlus/phonon-client/tlv"
 
@@ -76,15 +77,15 @@ func TLVDecodePublicPhononFields(phononTLV tlv.TLVCollection) (*model.Phonon, er
 	if err != nil && err != tlv.ErrTagNotFound {
 		return nil, err
 	}
-	if err == nil {
+	switch err {
+	case nil:
 		phonon.KeyIndex = binary.BigEndian.Uint16(keyIndexBytes)
-	} else if err == tlv.ErrTagNotFound {
+	case tlv.ErrTagNotFound:
 		log.Debug("phonon keyIndex not found during tlv parsing, skipping...")
-		//move on, missing KeyIndex is OK
-	} else {
+	default:
 		return nil, err
-	}
 
+	}
 	//CurveType
 	rawCurveType, err := phononTLV.FindTag(TagCurveType)
 	if err != nil {

--- a/card/phononCommandSet.go
+++ b/card/phononCommandSet.go
@@ -248,9 +248,10 @@ func checkPairingErrors(pairingStep int, status uint16) (err error) {
 	case 0x6882:
 		err = errors.New("certificate not loaded")
 	case 0x6982:
-		if pairingStep == 1 {
+		switch pairingStep {
+		case 1:
 			err = errors.New("unable to generate secret")
-		} else if pairingStep == 2 {
+		case 2:
 			err = errors.New("client cryptogram verification failed")
 		}
 	case 0x6A84:

--- a/card/phononCommandSet_test.go
+++ b/card/phononCommandSet_test.go
@@ -95,12 +95,12 @@ func TestCreateSetAndListPhonons(t *testing.T) {
 		value        model.Denomination
 	}
 	phononTable := []phononDescription{
-		{model.Bitcoin, model.Denomination{1, 0}},
-		{model.Bitcoin, model.Denomination{1, 8}},
-		{model.Bitcoin, model.Denomination{99, 6}},
-		{model.Ethereum, model.Denomination{1, 18}},
-		{model.Ethereum, model.Denomination{9, 18}},
-		{model.Ethereum, model.Denomination{1, 0}},
+		{model.Bitcoin, model.Denomination{Base: 1, Exponent: 0}},
+		{model.Bitcoin, model.Denomination{Base: 1, Exponent: 8}},
+		{model.Bitcoin, model.Denomination{Base: 99, Exponent: 6}},
+		{model.Ethereum, model.Denomination{Base: 1, Exponent: 18}},
+		{model.Ethereum, model.Denomination{Base: 9, Exponent: 18}},
+		{model.Ethereum, model.Denomination{Base: 1, Exponent: 0}},
 	}
 
 	type phononFilter struct {
@@ -219,7 +219,7 @@ func TestDestroyPhonon(t *testing.T) {
 	p := &model.Phonon{
 		KeyIndex:     keyIndex,
 		CurrencyType: model.Ethereum,
-		Denomination: model.Denomination{57, 0},
+		Denomination: model.Denomination{Base: 57, Exponent: 0},
 	}
 	err = cs.SetDescriptor(p)
 	if err != nil {
@@ -274,7 +274,8 @@ func TestFillPhononTable(t *testing.T) {
 	maxPhononCount := 256
 	var createdIndices []uint16
 	for i := 0; i < maxPhononCount-initialCount; i++ {
-		keyIndex, _, err := cs.CreatePhonon(model.Secp256k1)
+		var keyIndex uint16
+		keyIndex, _, err = cs.CreatePhonon(model.Secp256k1)
 		if err != nil {
 			t.Error(err)
 			return

--- a/card/secureChannel.go
+++ b/card/secureChannel.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"crypto/ecdsa"
 	"errors"
+	"strings"
+
 	"github.com/GridPlus/keycard-go/apdu"
 	"github.com/GridPlus/keycard-go/crypto"
 	"github.com/GridPlus/keycard-go/globalplatform"
@@ -11,7 +13,6 @@ import (
 	"github.com/GridPlus/keycard-go/types"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
 var ErrInvalidResponseMAC = errors.New("invalid response MAC")
@@ -105,7 +106,8 @@ func (sc *SecureChannel) Send(cmd *Command) (resp *apdu.Response, err error) {
 		}
 	}()
 	if sc.open {
-		encData, err := crypto.EncryptData(cmd.ApduCmd.Data, sc.encKey, sc.iv)
+		var encData []byte
+		encData, err = crypto.EncryptData(cmd.ApduCmd.Data, sc.encKey, sc.iv)
 		if err != nil {
 			return nil, err
 		}

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -198,7 +198,7 @@ func ParseRawCardCertificate(cardCertificateRaw []byte) (cert CardCertificate, e
 
 	if cert.Permissions.certLen == 0 || cert.Permissions.permLen == 0 {
 		log.Debugf("invalid certificate found: % X", cardCertificateRaw)
-		return CardCertificate{}, errors.New("card Certificate Invalid")
+		return CardCertificate{}, errors.New("card certificate invalid")
 	}
 	permsLen := int(cert.Permissions.permLen)
 	if len(cardCertificateRaw) < 5+permsLen {

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -140,8 +140,8 @@ func SignWithDemoKey(cert []byte) ([]byte, error) {
 
 	// print("signing with demo key")
 	key.D = new(big.Int).SetBytes(demoKey)
-	key.PublicKey.Curve = secp256k1.S256()
-	key.PublicKey.X, key.PublicKey.Y = key.PublicKey.Curve.ScalarBaseMult(key.D.Bytes())
+	key.Curve = secp256k1.S256()
+	key.X, key.Y = key.ScalarBaseMult(key.D.Bytes())
 	digest := sha256.Sum256(cert)
 	ret, err := key.Sign(rand.Reader, digest[:], nil)
 	if err != nil {
@@ -198,7 +198,7 @@ func ParseRawCardCertificate(cardCertificateRaw []byte) (cert CardCertificate, e
 
 	if cert.Permissions.certLen == 0 || cert.Permissions.permLen == 0 {
 		log.Debugf("invalid certificate found: % X", cardCertificateRaw)
-		return CardCertificate{}, errors.New("Card Certificate Invalid")
+		return CardCertificate{}, errors.New("card Certificate Invalid")
 	}
 	permsLen := int(cert.Permissions.permLen)
 	if len(cardCertificateRaw) < 5+permsLen {

--- a/cmd/GetFriendlyName.go
+++ b/cmd/GetFriendlyName.go
@@ -27,7 +27,7 @@ import (
 var getFriendlyNameCmd = &cobra.Command{
 	Use:   "getFriendlyName",
 	Short: "retrieve the card's previously set Friendly Name",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		getFriendlyName()
 	},
 }

--- a/cmd/JumpBox.go
+++ b/cmd/JumpBox.go
@@ -33,7 +33,7 @@ and usage of using your command. For example:
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		remote.StartServer(port, certificate, key)
 	},
 }

--- a/cmd/SetFriendlyName.go
+++ b/cmd/SetFriendlyName.go
@@ -28,7 +28,7 @@ var name string
 var setFriendlyNameCmd = &cobra.Command{
 	Use:   "setFriendlyName",
 	Short: "Set friendly name for phonon card",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		setFriendlyName()
 	},
 }

--- a/cmd/changePin.go
+++ b/cmd/changePin.go
@@ -29,7 +29,7 @@ var changePinCmd = &cobra.Command{
 	Short: "Change card's 6 digit PIN",
 	Long: `Change the card's existing 6 digit PIN to a new one.
 command will prompt you securely for the existing PIN as well as the new one.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		changePin()
 	},
 }

--- a/cmd/createPhonon.go
+++ b/cmd/createPhonon.go
@@ -34,7 +34,7 @@ when the SELECT command is run against the card again.
 
 Phonons created by this command have no identifying descriptor information.
 `,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		var n int
 		if len(args) < 1 {
 			n = 1

--- a/cmd/destroyPhonon.go
+++ b/cmd/destroyPhonon.go
@@ -32,7 +32,7 @@ var destroyPhononCmd = &cobra.Command{
 This allows one to utilize the phonon's private key outside of the phonon system,
 but the phonon will no longer be retrievable via the card.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		keyIndex, err := strconv.ParseUint(args[0], 10, 16)
 		if err != nil {
 			fmt.Println("couldn't parse keyIndex value as uint16: ", err)

--- a/cmd/generateCAKeypair.go
+++ b/cmd/generateCAKeypair.go
@@ -30,7 +30,7 @@ var generateCAKeypairCmd = &cobra.Command{
 	Long: `Generates a keypair for us as a phonon card certificate authority.
 	Prints the public and private key details in the string formats needed for inclusion
 	in the phonon-card and phonon-client source code. `,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		generateCAKeypair()
 	},
 }
@@ -96,7 +96,7 @@ func printJavacardfmt(key []byte) string {
 			width = 0
 		}
 		if b >= 0x80 {
-			result += fmt.Sprint("(byte) ")
+			result += "(byte) "
 		}
 		result += fmt.Sprintf("0x%02X, ", b)
 		width += 1

--- a/cmd/getAvailableMemory.go
+++ b/cmd/getAvailableMemory.go
@@ -28,7 +28,7 @@ var getAvailableMemoryCmd = &cobra.Command{
 	Short: "Retrieve the card's available memory statistics",
 	Long: `Retrieve the card's available memory statistics.
 	Returns persistent memory, transient memory on reset, then transient memory on deselect`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		cs, err := card.QuickSecureConnection(readerIndex, staticPairing)
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/getCertificate.go
+++ b/cmd/getCertificate.go
@@ -30,7 +30,7 @@ var getCertificateCmd = &cobra.Command{
 	Use:   "getCertificate",
 	Short: "Gets the card certificate and validates it's signature with the configured CA",
 	Long:  `Gets the card certificate and validates it's signature with the configured CA`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		getCertificate()
 	},
 }

--- a/cmd/getPhononPubKey.go
+++ b/cmd/getPhononPubKey.go
@@ -31,7 +31,7 @@ var getPhononPubKeyCmd = &cobra.Command{
 	Long: `Retrieves a phonon's public key by keyIndex. This may be necessary to follow up
 a list command, as LIST_PHONONS does not return public keys in order to conserve space.`,
 	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		keyIndex, err := strconv.Atoi(args[0])
 		if err != nil {
 			fmt.Println(err)

--- a/cmd/identifyCard.go
+++ b/cmd/identifyCard.go
@@ -33,7 +33,7 @@ var identifyCardCmd = &cobra.Command{
 	Short: "Request card identity information",
 	Long: `Requests the card return it's identity public key along with a signature over
 	a supplied nonce, proving it's possession of the correcsponding private key`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		identifyCard()
 	},
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,7 +29,7 @@ var initCmd = &cobra.Command{
 	Use:   "init [pin]",
 	Short: "Initialize phonon card with PIN.",
 	Long:  `Initialize phonon card with PIN. Defaults to 111111 if no argument is given`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, args []string) {
 		var pin string
 		if len(args) > 0 {
 			pin = args[0]

--- a/cmd/listPhonons.go
+++ b/cmd/listPhonons.go
@@ -30,7 +30,7 @@ var listPhononsCmd = &cobra.Command{
 	Long: `Lists all phonons on card matching the given filter, and returning the available phonon descriptor
 	`,
 	Args: cobra.ExactValidArgs(0),
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		listPhonons()
 	},
 }

--- a/cmd/mineNativePhonons.go
+++ b/cmd/mineNativePhonons.go
@@ -17,9 +17,10 @@ package cmd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/GridPlus/phonon-client/card"
 	"github.com/spf13/cobra"
-	"time"
 )
 
 // mineNativePhononsCmd represents the mineNativePhonons command
@@ -29,7 +30,7 @@ var mineNativePhononsCmd = &cobra.Command{
 	Long: `Begin mining native phonons.
 	If called with no arguments command will repeatedly mine for phonons until cancelled.
 	Pass a duration in go time syntax to mine for a specific duration instead.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		mineNativePhonons()
 	},
 }

--- a/cmd/openSecureChannel.go
+++ b/cmd/openSecureChannel.go
@@ -27,7 +27,7 @@ var openSecureChannelCmd = &cobra.Command{
 	Use:   "openSecureChannel",
 	Short: "Tests opening a secure channel",
 	Long:  `Tests opening a secure channel between terminal and card`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		openSecureChannel()
 	},
 }

--- a/cmd/pairCardToCard.go
+++ b/cmd/pairCardToCard.go
@@ -30,7 +30,7 @@ var pairCardToCardCmd = &cobra.Command{
 	Short: "Establish a pairing between 2 phonon cards",
 	Long: `Establish a local pairing between 2 phonon cards connected via
 	2 different card readers attached to the the same phonon-client terminal`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		PairCardToCard()
 	},
 }
@@ -83,7 +83,8 @@ func PairCardToCard() {
 	}
 
 	if useMockSender {
-		senderCardID, err := terminal.GenerateMock()
+		var senderCardID string
+		senderCardID, err = terminal.GenerateMock()
 		if err != nil {
 			log.Fatal("Unable to generate mock sender: " + err.Error())
 		}
@@ -99,7 +100,8 @@ func PairCardToCard() {
 	}
 	var receiverSession *orchestrator.Session
 	if useMockReceiver {
-		receiverCardID, err := terminal.GenerateMock()
+		var receiverCardID string
+		receiverCardID, err = terminal.GenerateMock()
 		if err != nil {
 			log.Fatal("Unable to generate mock receiver: " + err.Error())
 		}

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -24,7 +24,7 @@ import (
 var replCmd = &cobra.Command{
 	Use:   "repl",
 	Short: "Start the phonon repl frontend",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		repl.Start()
 	},
 }

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -27,7 +27,7 @@ var selectCmd = &cobra.Command{
 	Use:   "select",
 	Short: "Test SELECT command",
 	Long:  `Test SELECT command`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		cs, err := card.Connect(readerIndex)
 		if err != nil {
 			return

--- a/cmd/sendPhonons.go
+++ b/cmd/sendPhonons.go
@@ -29,7 +29,7 @@ var sendPhononsCmd = &cobra.Command{
 	Use:   "sendPhonons",
 	Short: "Send a packet of phonons",
 	Long:  `Send a packet of phonons with a list of keyIndices,`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		sendPhonons()
 	},
 }

--- a/cmd/setDescriptor.go
+++ b/cmd/setDescriptor.go
@@ -30,7 +30,7 @@ var setDescriptorCmd = &cobra.Command{
 	Short: "Set a description of a phonon",
 	Long: `Set a phonon description in order to store metadata that identifies which blockchain assets
 the phonon corresponds to, so that they can later be retrieved for use in transactions.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		setDescriptor()
 	},
 }

--- a/cmd/verifyPin.go
+++ b/cmd/verifyPin.go
@@ -28,7 +28,7 @@ var verifyPinCmd = &cobra.Command{
 	Use:   "verifyPin",
 	Short: "Test pin verification",
 	Long:  `Tests pin verification. Accepts PIN via secure cprompt`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		verifyPin()
 	},
 }

--- a/cmd/webUI.go
+++ b/cmd/webUI.go
@@ -18,7 +18,7 @@ var webUICmd = &cobra.Command{
 	Long: `Start a rest api to handle operations with the card.
 	Meant to be paired with a graphical frontend. Not for production
 	use as there is currently no security beyond the pin of the card.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(_ *cobra.Command, _ []string) {
 		gui.Server(guiPort, guiCert, guiKey, useMock)
 	},
 }

--- a/orchestrator/localCounterParty.go
+++ b/orchestrator/localCounterParty.go
@@ -71,7 +71,7 @@ func (lcp *localCounterParty) VerifyPaired() error {
 	if lcp.pairingStatus == model.StatusPaired {
 		return nil
 	} else {
-		return fmt.Errorf("Not paired to local counterparty")
+		return fmt.Errorf("not paired to local counterparty")
 	}
 }
 

--- a/orchestrator/terminal.go
+++ b/orchestrator/terminal.go
@@ -18,7 +18,7 @@ type remoteSession struct {
 }
 
 var ErrRemoteNotPaired error = errors.New("no remote card paired")
-var ErrNoSession error = errors.New("No connected session with id found")
+var ErrNoSession error = errors.New("no connected session with id found")
 
 var globalTerminal *PhononTerminal
 

--- a/remote/v1/client/client.go
+++ b/remote/v1/client/client.go
@@ -137,7 +137,7 @@ func Connect(sessReqChan chan model.SessionRequest, url string, ignoreTLS bool) 
 
 	conn, resp, err := d.Connect(context.Background(), url) //url)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect to remote server %e,", err)
+		return nil, fmt.Errorf("unable to connect to remote server %e,", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		log.Error("received bad status from jumpbox. err: ", resp.Status)
@@ -193,7 +193,7 @@ func Connect(sessReqChan chan model.SessionRequest, url string, ignoreTLS bool) 
 	select {
 	case <-client.identifiedWithServerChan:
 	case <-time.After(time.Second * 10):
-		return nil, fmt.Errorf("Verification with server timed out")
+		return nil, fmt.Errorf("verification with server timed out")
 	}
 
 	client.pairingStatus = model.StatusConnectedToBridge

--- a/repl/mock.go
+++ b/repl/mock.go
@@ -6,9 +6,9 @@ import (
 	"github.com/abiosoft/ishell/v2"
 )
 
-func addMock(c *ishell.Context){
+func addMock(_ *ishell.Context) {
 	_, err := t.GenerateMock()
-	if err != nil{
+	if err != nil {
 		fmt.Println("Error generating mock phonon card")
 	}
 

--- a/repl/pin.go
+++ b/repl/pin.go
@@ -2,6 +2,7 @@ package repl
 
 import (
 	"fmt"
+
 	ishell "github.com/abiosoft/ishell/v2"
 )
 
@@ -32,7 +33,7 @@ func unlockCard(c *ishell.Context) {
 	//TODO: update chain of functions to return triesRemaining to callers
 	err = activeCard.VerifyPIN(pin)
 	if err != nil {
-		c.Err(fmt.Errorf("Unable to unlock card %s", err.Error()))
+		c.Err(fmt.Errorf("unable to unlock card %s", err.Error()))
 		return
 	}
 	c.Println("card successfully unlocked")

--- a/util/crypto.go
+++ b/util/crypto.go
@@ -33,7 +33,8 @@ func ParseECCPubKey(rawPubKey []byte) (pubKey *ecdsa.PublicKey, err error) {
 	if len(rawPubKey) == 0 {
 		return nil, errors.New("pubKey was zero length")
 	}
-	if rawPubKey[0] == 0x04 {
+	switch rawPubKey[0] {
+	case 0x04:
 		//Unmarshal uncompressed pubkey format
 		pubKey, err = ethcrypto.UnmarshalPubkey(rawPubKey)
 		if err != nil {
@@ -41,16 +42,17 @@ func ParseECCPubKey(rawPubKey []byte) (pubKey *ecdsa.PublicKey, err error) {
 			log.Error("raw pubkey:\n", hex.Dump(rawPubKey))
 			return nil, err
 		}
-	} else if rawPubKey[0] == 0x02 || rawPubKey[0] == 0x03 {
+	case 0x02, 0x03:
 		//Unmarshal compressed pubkey format
 		pubKey, err = ethcrypto.DecompressPubkey(rawPubKey)
 		if err != nil {
 			log.Error("could not unmarshal compressed ecdsa pub key from raw: ", err)
 			return nil, err
 		}
-	} else {
+	default:
 		log.Debugf("could not detect ECC pubkey format from key: % X\n", rawPubKey)
 		return nil, ErrInvalidECCPubKeyFormat
+
 	}
 
 	return pubKey, nil


### PR DESCRIPTION
updates to each of the go files to make the gopls linter stop complaining. The fixes are including but not limited to the following:
1. lowercasing error messages
2. turning long if/else statements into switch case
3. assigning unused identifiers to the "_" sink
4. removing unnecessary sprint statements