### PR TITLE
removed AppletCACert field from config in favor of strict use of cert…

### DIFF
--- a/card/phononCommandSet.go
+++ b/card/phononCommandSet.go
@@ -86,7 +86,7 @@ func NewPhononCommandSet(c types.Channel) *PhononCommandSet {
 		c:               c,
 		sc:              NewSecureChannel(c),
 		ApplicationInfo: &types.ApplicationInfo{},
-		PhononCACert:    conf.AppletCACert,
+		PhononCACert:    cert.SelectCACertByName(conf.Certificate),
 	}
 }
 

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/GridPlus/phonon-client/util"
 	yubihsm "github.com/certusone/yubihsm-go"
@@ -92,7 +93,7 @@ func ValidateCardCertificate(cert CardCertificate, CAPubKey []byte) error {
 		log.Error("could not parse CAPubKey: ", err)
 		return err
 	}
-	log.Debug("certificate CA PubKey was valid")
+	log.Debug("certificate authority pubkey was valid")
 	signature, err := util.ParseECDSASignature(cert.Sig)
 	if err != nil {
 		log.Error("could not parse cert signature: ", err)
@@ -251,4 +252,16 @@ func (cert CardCertificate) Serialize() []byte {
 
 func (cert CardCertificate) String() string {
 	return fmt.Sprintf("Permissions: % X, PubKey: % X (length: %v), Sig: % X (length %v)", cert.Permissions, cert.PubKey, len(cert.PubKey), cert.Sig, len(cert.Sig))
+}
+
+func SelectCACertByName(name string) []byte {
+	//Select cert based on provided certificate name
+	switch strings.ToLower(name) {
+	case "alpha", "testnet":
+		return PhononAlphaCAPubKey
+	case "dev", "demo":
+		return PhononDemoCAPubKey
+	default:
+		return PhononAlphaCAPubKey
+	}
 }

--- a/cmd/getCertificate.go
+++ b/cmd/getCertificate.go
@@ -72,9 +72,10 @@ func getCertificate() {
 	}
 	fmt.Println("Certificate: ", cardCert)
 	//Validate cert matches configured CA
-	err = cert.ValidateCardCertificate(*cardCert, conf.AppletCACert)
+	caCert := cert.SelectCACertByName(conf.Certificate)
+	err = cert.ValidateCardCertificate(*cardCert, caCert)
 	if err != nil {
-		fmt.Printf("error validating card certificate %v against CA certificate %v. err: %v\n", *cardCert, conf.AppletCACert, err)
+		fmt.Printf("error validating card certificate %v against CA certificate %v. err: %v\n", *cardCert, caCert, err)
 		return
 	}
 	fmt.Println("getCertificate command successfully validated cert")

--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 
-	"github.com/GridPlus/phonon-client/cert"
 	"github.com/GridPlus/phonon-client/hooks"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -16,8 +14,7 @@ type Config struct {
 	//Global
 	LogLevel log.Level //A logrus logLevel
 	//PhononCommandSet
-	AppletCACert []byte //One of the CA certificates listed in the cert package. Used as default if Certificate not set
-	Certificate  string //string ID to select a certificate
+	Certificate string //string ID to select a certificate
 	// log exporting
 	TelemetryKey string
 }
@@ -25,15 +22,13 @@ type Config struct {
 func DefaultConfig() Config {
 	//Add viper/commandline integration later
 	conf := Config{
-		Certificate:  "alpha",
-		AppletCACert: cert.PhononAlphaCAPubKey,
-		LogLevel:     log.DebugLevel,
+		Certificate: "alpha",
+		LogLevel:    log.DebugLevel,
 	}
 	return conf
 }
 
 func SetDefaultConfig() {
-	viper.SetDefault("AppletCACert", cert.PhononAlphaCAPubKey)
 	viper.SetDefault("LogLevel", log.DebugLevel)
 }
 
@@ -76,17 +71,6 @@ func LoadConfig() (config Config, err error) {
 		log.AddHook(hooks.NewLoggingHook(config.TelemetryKey))
 	}
 
-	//Select cert based on provided certificate name
-	if config.Certificate != "" {
-		switch strings.ToLower(config.Certificate) {
-		case "alpha", "testnet":
-			break
-		case "dev", "demo":
-			config.AppletCACert = cert.PhononDemoCAPubKey
-		default:
-			break
-		}
-	}
 	return config, nil
 }
 


### PR DESCRIPTION
…ificate key in config. added SelectCACertByName function to cert to map named keys to CA cert bytes. 

Done to prevent viper from writing out wonky data for the certificate bytes into user's config files when they are automatically saved.  