### PR TITLE
adds testnet supported chains to be returned at endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ phonon_arm64
 phonon_x86_64
 release/MacOS/Phonon.app/Contents/MacOS/phonon_arm64
 release/MacOS/Phonon.app/Contents/MacOS/phonon_x86_64
+result

--- a/chain/ethChainService.go
+++ b/chain/ethChainService.go
@@ -39,18 +39,18 @@ type supportedChains struct {
 	CurrencyType uint
 }
 
+var chains = []supportedChains{
+	{ChainID: 3, Ticker: "ETH", Name: "Ropsten", CurrencyType: 2},
+	{ChainID: 42, Ticker: "ETH", Name: "Kovan", CurrencyType: 2},
+	{ChainID: 0, Ticker: "nPhonon", Name: "Native", CurrencyType: 3},
+	{ChainID: 4, Ticker: "RINKEBY-EITH", Name: "Rinkeby", CurrencyType: 2},
+	{ChainID: 5, Ticker: "GOERLI-EITH", Name: "Goerli", CurrencyType: 2},
+	{ChainID: 56, Ticker: "BNB", Name: "binance-testnet", CurrencyType: 2},
+	{ChainID: 80001, Ticker: "MATIC-TEST", Name: "polygon-testnet", CurrencyType: 2},
+	{ChainID: 42113, Ticker: "AVAX-TEST", Name: "avalanche-mainnet", CurrencyType: 2},
+}
+
 func GetSupportedChains() []supportedChains {
-	var chains []supportedChains
-
-	chains = append(chains, supportedChains{ChainID: 3, Ticker: "ETH", Name: "Ropsten", CurrencyType: 2})
-	chains = append(chains, supportedChains{ChainID: 42, Ticker: "ETH", Name: "Kovan", CurrencyType: 2})
-	chains = append(chains, supportedChains{ChainID: 0, Ticker: "nPhonon", Name: "Native", CurrencyType: 3})
-	chains = append(chains, supportedChains{ChainID: 4, Ticker: "RINKEBY-EITH", Name: "Rinkeby", CurrencyType: 2})
-	chains = append(chains, supportedChains{ChainID: 5, Ticker: "GOERLI-EITH", Name: "Goerli", CurrencyType: 2})
-	chains = append(chains, supportedChains{ChainID: 56, Ticker: "BNB", Name: "binance-testnet", CurrencyType: 2})
-	chains = append(chains, supportedChains{ChainID: 80001, Ticker: "MATIC-TEST", Name: "polygon-testnet", CurrencyType: 2})
-	chains = append(chains, supportedChains{ChainID: 42113, Ticker: "AVAX-TEST", Name: "avalanche-mainnet", CurrencyType: 2})
-
 	return chains
 }
 

--- a/chain/ethChainService.go
+++ b/chain/ethChainService.go
@@ -21,7 +21,7 @@ import (
 var ErrGasCostExceedsRedeemValue = errors.New("cannot redeem phonon where gas cost would exceed on chain balance")
 var ErrRedeemAddressInvalid = errors.New("redeem address is invalid")
 
-//Composite interface supporting all needed EVM RPC calls
+// Composite interface supporting all needed EVM RPC calls
 type EthChainInterface interface {
 	bind.ContractTransactor
 	ethereum.ChainStateReader
@@ -30,6 +30,28 @@ type EthChainService struct {
 	gasLimit  uint64
 	cl        EthChainInterface //*ethclient.Client // //bind.ContractTransactor
 	clChainID int
+}
+
+type supportedChains struct {
+	ChainID      uint
+	Ticker       string
+	Name         string
+	CurrencyType uint
+}
+
+func GetSupportedChains() []supportedChains {
+	var chains []supportedChains
+
+	chains = append(chains, supportedChains{ChainID: 3, Ticker: "ETH", Name: "Ropsten", CurrencyType: 2})
+	chains = append(chains, supportedChains{ChainID: 42, Ticker: "ETH", Name: "Kovan", CurrencyType: 2})
+	chains = append(chains, supportedChains{ChainID: 0, Ticker: "nPhonon", Name: "Native", CurrencyType: 3})
+	chains = append(chains, supportedChains{ChainID: 4, Ticker: "RINKEBY-EITH", Name: "Rinkeby", CurrencyType: 2})
+	chains = append(chains, supportedChains{ChainID: 5, Ticker: "GOERLI-EITH", Name: "Goerli", CurrencyType: 2})
+	chains = append(chains, supportedChains{ChainID: 56, Ticker: "BNB", Name: "binance-testnet", CurrencyType: 2})
+	chains = append(chains, supportedChains{ChainID: 80001, Ticker: "MATIC-TEST", Name: "polygon-testnet", CurrencyType: 2})
+	chains = append(chains, supportedChains{ChainID: 42113, Ticker: "AVAX-TEST", Name: "avalanche-mainnet", CurrencyType: 2})
+
+	return chains
 }
 
 func NewEthChainService() (*EthChainService, error) {
@@ -215,8 +237,8 @@ func (eth *EthChainService) submitLegacyTransaction(ctx context.Context, nonce u
 	return signedTx, nil
 }
 
-//Hacky function to ensure a phonon can be redeemed before an irreversible DESTROY_PHONON command is executed to redeem it.
-//Returns an error if the phonon can't be redeemed, or nil if it can
+// Hacky function to ensure a phonon can be redeemed before an irreversible DESTROY_PHONON command is executed to redeem it.
+// Returns an error if the phonon can't be redeemed, or nil if it can
 func (eth *EthChainService) CheckRedeemable(p *model.Phonon, redeemAddress string) (err error) {
 	//Check that fromAddress exists, if not derive it
 	if p.Address == "" {

--- a/gui/api.go
+++ b/gui/api.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/GridPlus/phonon-client/chain"
 	"github.com/GridPlus/phonon-client/config"
 	"github.com/GridPlus/phonon-client/model"
 	"github.com/GridPlus/phonon-client/orchestrator"
@@ -108,6 +109,7 @@ func Server(port string, certFile string, keyFile string, mock bool) {
 	r.HandleFunc("/cards/{sessionID}/connectionStatus", session.RemoteConnectionStatus)
 	r.HandleFunc("/cards/{sessionID}/connectLocal", session.ConnectLocal)
 	r.HandleFunc("/checkDenomination", verifyDenomination)
+	r.HandleFunc("/listChains", listChains)
 	// api docs
 	r.PathPrefix("/swagger/").Handler(http.StripPrefix("/", http.FileServer(http.FS(swagger))))
 	r.HandleFunc("/swagger.json", serveAPIFunc(port))
@@ -248,6 +250,16 @@ func parseJSLogLevel(input interface{}) (int, error) {
 	}
 	lvlInt := int(lvlFloat64)
 	return lvlInt, nil
+}
+
+func listChains(w http.ResponseWriter, r *http.Request) {
+	chains := chain.GetSupportedChains()
+
+	err := json.NewEncoder(w).Encode(chains)
+	if err != nil {
+		http.Error(w, "unable to encode supported chains: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 func (apiSession apiSession) createPhonon(w http.ResponseWriter, r *http.Request) {

--- a/gui/swagger.yaml
+++ b/gui/swagger.yaml
@@ -525,6 +525,30 @@ paths:
             schema:
               type: string
         required: true
+  /listChains:
+    post:
+      tags:
+        - general
+      summary: list the chains that the testnet supports
+      responses:
+        "200":
+          description: return list of chains for testnet
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties:
+                    ChainId:
+                      type: number
+                    Ticker:
+                      type: string
+                    Name:
+                      type: string
+                    CurrencyType:
+                      type: number
+        "500":
+          description: unable to list chains
 components:
   requestBodies:
     Body:


### PR DESCRIPTION
This PR references the list of chains in the GUI's frontend and provides support to return the specific list of testnet chains from an endpoint called `/listchains`.