### PR TITLE
Issue-239

### DIFF
--- a/chain/ethChainService.go
+++ b/chain/ethChainService.go
@@ -21,7 +21,7 @@ import (
 var ErrGasCostExceedsRedeemValue = errors.New("cannot redeem phonon where gas cost would exceed on chain balance")
 var ErrRedeemAddressInvalid = errors.New("redeem address is invalid")
 
-//Composite interface supporting all needed EVM RPC calls
+// Composite interface supporting all needed EVM RPC calls
 type EthChainInterface interface {
 	bind.ContractTransactor
 	ethereum.ChainStateReader
@@ -29,7 +29,7 @@ type EthChainInterface interface {
 type EthChainService struct {
 	gasLimit  uint64
 	cl        EthChainInterface //*ethclient.Client // //bind.ContractTransactor
-	clChainID int
+	clChainID uint32
 }
 
 func NewEthChainService() (*EthChainService, error) {
@@ -118,7 +118,7 @@ func (eth *EthChainService) ValidateRedeemData(p *model.Phonon, privKey *ecdsa.P
 }
 
 // dialRPCNode establishes a connection to the proper RPC node based on the chainID
-func (eth *EthChainService) dialRPCNode(chainID int) (err error) {
+func (eth *EthChainService) dialRPCNode(chainID uint32) (err error) {
 	log.Debugf("ethChainID: %v, chainID: %v\n", eth.clChainID, chainID)
 	var RPCEndpoint string
 	//If chainID is already set, correct RPC node is already connected
@@ -215,8 +215,8 @@ func (eth *EthChainService) submitLegacyTransaction(ctx context.Context, nonce u
 	return signedTx, nil
 }
 
-//Hacky function to ensure a phonon can be redeemed before an irreversible DESTROY_PHONON command is executed to redeem it.
-//Returns an error if the phonon can't be redeemed, or nil if it can
+// Hacky function to ensure a phonon can be redeemed before an irreversible DESTROY_PHONON command is executed to redeem it.
+// Returns an error if the phonon can't be redeemed, or nil if it can
 func (eth *EthChainService) CheckRedeemable(p *model.Phonon, redeemAddress string) (err error) {
 	//Check that fromAddress exists, if not derive it
 	if p.Address == "" {

--- a/chain/ethChainService_test.go
+++ b/chain/ethChainService_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
+
 	// "github.com/ethereum/go-ethereum/core/types"
 
 	// "github.com/ethereum/go-ethereum/common"
@@ -42,8 +43,8 @@ func getSimEVM() (*backends.SimulatedBackend, error) {
 	return simEVM, nil
 }
 
-//TestEthChainServiceRedeem smoke tests the basic redeem funtionality using a ganache backend.
-//Ganache must be stood up manually and this test must be hand edited with valid keys to function.
+// TestEthChainServiceRedeem smoke tests the basic redeem funtionality using a ganache backend.
+// Ganache must be stood up manually and this test must be hand edited with valid keys to function.
 func TestEthChainServiceRedeem(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 
@@ -70,9 +71,8 @@ func TestEthChainServiceRedeem(t *testing.T) {
 	}
 
 	//Manually substitute simulated backend for usual RPC client
-	testChainID := 1337
 	eth.cl = sim
-	eth.clChainID = testChainID
+	eth.clChainID = 1337
 
 	pubKey, err := model.NewPhononPubKey(crypto.FromECDSAPub(&senderPrivKey.PublicKey), model.Secp256k1)
 	if err != nil {
@@ -83,7 +83,7 @@ func TestEthChainServiceRedeem(t *testing.T) {
 		KeyIndex:     1,
 		PubKey:       pubKey,
 		CurrencyType: model.Ethereum,
-		ChainID:      testChainID,
+		ChainID:      eth.clChainID,
 	}
 	p.Address, err = eth.DeriveAddress(p)
 	if err != nil {
@@ -99,7 +99,7 @@ func TestEthChainServiceRedeem(t *testing.T) {
 	fixedGasPrice := big.NewInt(875000000)
 	phononValue := big.NewInt(10000000000000000)
 	_, err = eth.submitLegacyTransaction(ctx, nonce,
-		big.NewInt(int64(testChainID)),
+		big.NewInt(int64(eth.clChainID)),
 		common.HexToAddress(p.Address),
 		phononValue,
 		eth.gasLimit,

--- a/model/phonon.go
+++ b/model/phonon.go
@@ -27,7 +27,7 @@ type Phonon struct {
 	ExtendedSchemaVersion uint8
 	Denomination          Denomination
 	CurrencyType          CurrencyType
-	ChainID               int
+	ChainID               uint32
 	ExtendedTLV           tlv.TLVList
 	Address               string //chain specific attribute not stored on card
 	AddressType           uint8  //chain specific address type identifier
@@ -47,7 +47,7 @@ func (p *Phonon) String() string {
 		p.ExtendedTLV)
 }
 
-//Phonon data structured for display to the user and use in frontends
+// Phonon data structured for display to the user and use in frontends
 type PhononJSON struct {
 	KeyIndex              PhononKeyIndex
 	PubKey                string //pubkey as hexstring
@@ -57,11 +57,11 @@ type PhononJSON struct {
 	ExtendedSchemaVersion uint8
 	Denomination          Denomination
 	CurrencyType          int
-	ChainID               int
+	ChainID               uint32
 	CurveType             uint8
 }
 
-//Unmarshals a PhononUserView into an internal phonon representation
+// Unmarshals a PhononUserView into an internal phonon representation
 func (p *Phonon) UnmarshalJSON(b []byte) error {
 	phJSON := PhononJSON{}
 	err := json.Unmarshal(b, &phJSON)
@@ -145,8 +145,8 @@ type Denomination struct {
 
 var ErrInvalidDenomination = errors.New("value cannot be represented as a phonon denomination")
 
-//NewDenomination takes an integer input and attempts to store it as a compressible value representing currency base units
-//Precision is limited to significant digits no greater than the value 255, along with exponentiation up to 255 digits
+// NewDenomination takes an integer input and attempts to store it as a compressible value representing currency base units
+// Precision is limited to significant digits no greater than the value 255, along with exponentiation up to 255 digits
 func NewDenomination(i *big.Int) (Denomination, error) {
 	var exponent uint8
 	maxUint8 := big.NewInt(int64(math.MaxUint8))
@@ -223,7 +223,7 @@ func (pubKey *ECCPubKey) Equal(x PhononPubKey) bool {
 	return pubKey.PubKey.Equal(xx.PubKey)
 }
 
-//Convenience function to easily convert PhononPublicKeys to their underyling concrete type when possible
+// Convenience function to easily convert PhononPublicKeys to their underyling concrete type when possible
 func PhononPubKeyToECDSA(pubKey PhononPubKey) (*ecdsa.PublicKey, error) {
 	ecc, ok := pubKey.(*ECCPubKey)
 	if !ok {
@@ -261,7 +261,7 @@ func (nat *NativePubKey) Equal(x PhononPubKey) bool {
 	return bytes.Equal(nat.Hash, xx.Hash)
 }
 
-//NewPhononPubKey parses raw public key data into the assigned PhononPubKey interface based on the given CurveType
+// NewPhononPubKey parses raw public key data into the assigned PhononPubKey interface based on the given CurveType
 func NewPhononPubKey(rawPubKey []byte, crv CurveType) (pubKey PhononPubKey, err error) {
 	//Switch pubkey interface based on given curveType
 	switch crv {
@@ -276,7 +276,7 @@ func NewPhononPubKey(rawPubKey []byte, crv CurveType) (pubKey PhononPubKey, err 
 	}
 }
 
-//Unmarshal Denominations from string to internal representation
+// Unmarshal Denominations from string to internal representation
 func (d *Denomination) UnmarshalJSON(b []byte) error {
 	var denomString string
 	err := json.Unmarshal(b, &denomString)
@@ -296,7 +296,7 @@ func (d *Denomination) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-//Marshal denominations as strings
+// Marshal denominations as strings
 func (d *Denomination) MarshalJSON() ([]byte, error) {
 	dString := d.String()
 	data, err := json.Marshal(dString)

--- a/repl/phonons.go
+++ b/repl/phonons.go
@@ -112,7 +112,7 @@ func setDescriptor(c *ishell.Context) {
 		KeyIndex:     model.PhononKeyIndex(keyIndex),
 		CurrencyType: currencyType,
 		Denomination: denomination,
-		ChainID:      chainID,
+		ChainID:      uint32(chainID),
 	}
 
 	err = activeCard.SetDescriptor(p)


### PR DESCRIPTION
Closes #239 

I've identified why chainId is being misreported for some chains after client restart.

The correct chainId is added to the cache but was not being stored correctly on the card. On client reset the cache is cleared breaking the UI. 

I have supplied a fix but not sure if this is the best solution. Should at least give someone with more knowledge a starting point. 

