### PR TITLE
Fixes missing arguments in tests

### DIFF
--- a/card/phononCommandSet_test.go
+++ b/card/phononCommandSet_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/GridPlus/keycard-go/io"
+	"github.com/GridPlus/phonon-client/config"
 	"github.com/GridPlus/phonon-client/model"
 	"github.com/GridPlus/phonon-client/usb"
 	"github.com/google/go-cmp/cmp"
@@ -24,7 +25,7 @@ func TestSelect(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	cs := NewPhononCommandSet(io.NewNormalChannel(card))
+	cs := NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig())
 	if err != nil {
 		t.Error(err)
 		return
@@ -59,7 +60,7 @@ func TestOpenSecureConnection(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	cs := NewPhononCommandSet(io.NewNormalChannel(card))
+	cs := NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig())
 	err = cs.OpenSecureConnection()
 	if err != nil {
 		t.Error(err)
@@ -78,7 +79,7 @@ func TestCreateSetAndListPhonons(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	cs := NewPhononCommandSet(io.NewNormalChannel(card))
+	cs := NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig())
 	err = cs.OpenSecureConnection()
 	if err != nil {
 		t.Error(err)
@@ -201,7 +202,7 @@ func TestDestroyPhonon(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	cs := NewPhononCommandSet(io.NewNormalChannel(card))
+	cs := NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig())
 	err = cs.OpenSecureConnection()
 	if err != nil {
 		t.Error(err)
@@ -255,7 +256,7 @@ func TestFillPhononTable(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	cs := NewPhononCommandSet(io.NewNormalChannel(card))
+	cs := NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig())
 	err = cs.OpenSecureConnection()
 	if err != nil {
 		t.Error(err)
@@ -309,7 +310,7 @@ func TestReuseDestroyedIndex(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	cs := NewPhononCommandSet(io.NewNormalChannel(card))
+	cs := NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig())
 	err = cs.OpenSecureConnection()
 	if err != nil {
 		t.Error(err)
@@ -404,7 +405,7 @@ func TestIncompletePairing(t *testing.T) {
 		return
 	}
 	//Use static command set to generate debugger logs
-	cs := NewStaticPhononCommandSet(NewPhononCommandSet(io.NewNormalChannel(card)))
+	cs := NewStaticPhononCommandSet(NewPhononCommandSet(io.NewNormalChannel(card), config.DefaultConfig()))
 
 	keyIndex, err := prepareCardForPairingTest(cs)
 	if err != nil {

--- a/orchestrator/localCounterParty_test.go
+++ b/orchestrator/localCounterParty_test.go
@@ -5,14 +5,16 @@ import (
 
 	// "github.com/GridPlus/phonon-client/card"
 	// "github.com/GridPlus/phonon-client/cert"
+	"github.com/GridPlus/phonon-client/config"
 	"github.com/GridPlus/phonon-client/orchestrator"
+
 	// "github.com/GridPlus/phonon-client/util"
 	"github.com/sirupsen/logrus"
 )
 
 func TestCardToCardPair(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
-	term := orchestrator.NewPhononTerminal()
+	term := orchestrator.NewPhononTerminal(config.DefaultConfig())
 	sessions, err := term.RefreshSessions()
 	if err != nil {
 		t.Error(err)

--- a/orchestrator/session_test.go
+++ b/orchestrator/session_test.go
@@ -3,6 +3,7 @@ package orchestrator_test
 import (
 	"testing"
 
+	"github.com/GridPlus/phonon-client/config"
 	"github.com/GridPlus/phonon-client/model"
 	"github.com/GridPlus/phonon-client/orchestrator"
 	"github.com/GridPlus/phonon-client/remote/v1/server"
@@ -30,7 +31,7 @@ func TestE2EJumpboxSendPhonon(t *testing.T) {
 	//todo: fix this
 
 	go server.StartServer("42069", "/Users/nate/Documents/localhost.cer.pem", "/Users/nate/Documents/localhost.key.pem")
-	term := orchestrator.NewPhononTerminal()
+	term := orchestrator.NewPhononTerminal(config.DefaultConfig())
 	mock1, _ := term.GenerateMock()
 	mock2, _ := term.GenerateMock()
 
@@ -67,7 +68,7 @@ func TestE2EJumpboxSendPhonon(t *testing.T) {
 
 func TestE2ELocalSendPhonon(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
-	term := orchestrator.NewPhononTerminal()
+	term := orchestrator.NewPhononTerminal(config.DefaultConfig())
 	mock1, _ := term.GenerateMock()
 	mock2, _ := term.GenerateMock()
 


### PR DESCRIPTION
As changes were made to the command set, requiring the config. This PR uses the default config provided in the package `config`, for all the test cases.