### PR TITLE
Adds mine native in repl

### DIFF
--- a/orchestrator/session.go
+++ b/orchestrator/session.go
@@ -309,6 +309,50 @@ func (s *Session) MineNativePhonon(difficulty uint8) (string, error) {
 	return id, nil
 }
 
+func (s *Session) MineNative(difficulty int) error {
+	if !s.verified() {
+		return card.ErrPINNotEntered
+	}
+
+	s.ElementUsageMtex.Lock()
+	defer s.ElementUsageMtex.Unlock()
+
+	start := time.Now()
+	var i int
+	for i = 1; i > 0; i++ {
+		elapsed := time.Since(start)
+		averageTime := time.Duration(float64(elapsed.Nanoseconds()) / float64(i))
+
+		fmt.Println("Mining attempt #", i)
+		keyIndex, hash, err := s.cs.MineNativePhonon(uint8(difficulty))
+		fmt.Println("Mining duration: ", elapsed)
+		if err == card.ErrMiningFailed {
+			fmt.Println("mining failed to find a phonon, retrying...")
+			fmt.Println("mining time started: ", start)
+			fmt.Println("mining time elapsed: ", elapsed)
+			fmt.Println("mining average time: ", averageTime)
+		} else if err != nil {
+			fmt.Println("unknown error mining phonon. Error: ", err)
+			fmt.Println("mining time started: ", start)
+			fmt.Println("mining time elapsed: ", elapsed)
+			fmt.Println("mining time stopped: ", time.Now())
+			return err
+		} else {
+			fmt.Printf("mined native phonon after %d attempts\n", i)
+			fmt.Println("mining time started: ", start)
+			fmt.Println("mining time elapsed: ", elapsed)
+			fmt.Println("mining time stopped: ", time.Now())
+			fmt.Println("mining average time: ", averageTime)
+			fmt.Printf("key index: %d\n", keyIndex)
+			fmt.Printf("hash: %x\n", hash)
+			break
+		}
+	}
+	fmt.Printf("\nmining completed with difficulty of %v bit(s): \n", difficulty)
+	fmt.Println("total mining attempts: ", i)
+	return nil
+}
+
 func (s *Session) GetCardId() string {
 	//If identity public key has already been cached by pairing, return it
 	if s.identityPubKey != nil {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -2,6 +2,7 @@ package repl
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/GridPlus/phonon-client/config"
@@ -133,6 +134,12 @@ func Start() {
 		Func: setName,
 		Help: "set the name of the active card",
 	})
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "mineNative",
+		Func: mineNative,
+		Help: "mine native tokens on the active card",
+	})
 	//Automatically refresh connections as the user is dropped into the shell
 	shell.Process("refresh")
 	shell.Run()
@@ -219,6 +226,32 @@ func listCards(c *ishell.Context) {
 				c.Printf("%v - %v\n", s.GetCardId(), name)
 			}
 		}
+	}
+}
+
+func mineNative(c *ishell.Context) {
+	if ready := checkActiveCard(c); !ready {
+		return
+	}
+
+	numCorrectArgs := 1
+	if len(c.Args) != numCorrectArgs {
+		c.Printf("mineNative requires %v arguments, %v provided")
+		return
+	}
+
+	difficulty := c.Args[0]
+
+	difficultyToInt, err := strconv.Atoi(difficulty)
+	if err != nil {
+		c.Printf("difficulty must be an integer")
+		return
+	}
+
+	err = activeCard.MineNative(difficultyToInt)
+	if err != nil {
+		c.Printf("error mining native tokens: %v", err)
+		return
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to add the mine native command in the repl. It uses its own specific function as the repl does not utilize channels and or the status report. It simply uses a for loop with messages printing to the console. The repl specifically requires an argument that is an integer, but I can also add a limit to prevent users from "bricking" their card.